### PR TITLE
core : optimization - removed unnecessary CompoundTerm copying

### DIFF
--- a/nars_core/nars/control/ConceptProcessing.java
+++ b/nars_core/nars/control/ConceptProcessing.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import nars.config.Parameters;
 import nars.entity.*;
-import nars.inference.BudgetFunctions;
 import nars.inference.SyllogisticRules;
 import nars.inference.TemporalRules;
 import nars.inference.TruthFunctions;
@@ -185,8 +184,8 @@ public class ConceptProcessing {
                                 //at first we have to remove the last one with same content from table
                                 int i_delete = -1;
                                 for(int i=0; i < pred_conc.executable_preconditions.size(); i++) {
-                                    if(CompoundTerm.cloneDeepReplaceIntervals(pred_conc.executable_preconditions.get(i).getTerm()).equals(
-                                            CompoundTerm.cloneDeepReplaceIntervals(strongest_target.getTerm()))) {
+                                    if(CompoundTerm.replaceIntervals(pred_conc.executable_preconditions.get(i).getTerm()).equals(
+                                            CompoundTerm.replaceIntervals(strongest_target.getTerm()))) {
                                         i_delete = i; //even these with same term but different intervals are removed here
                                         break;
                                     }
@@ -580,7 +579,7 @@ public class ConceptProcessing {
         for(TaskLink tl : concept.taskLinks) { //search for input in tasklinks (beliefs alone can not take temporality into account as the eternals will win)
             Task t = tl.targetTask;
             if(t!= null && t.sentence.isJudgment() && t.isInput() && !t.sentence.isEternal() && t.sentence.truth.getExpectation() > Parameters.DEFAULT_CONFIRMATION_EXPECTATION &&
-                    CompoundTerm.cloneDeepReplaceIntervals(t.sentence.term).equals(CompoundTerm.cloneDeepReplaceIntervals(concept.getTerm()))) {
+                    CompoundTerm.replaceIntervals(t.sentence.term).equals(CompoundTerm.replaceIntervals(concept.getTerm()))) {
                 if(t.sentence.getOccurenceTime() >= concept.negConfirm_abort_mintime && t.sentence.getOccurenceTime() <= concept.negConfirm_abort_maxtime) {
                     cancelled = true;
                     break;

--- a/nars_core/nars/control/TemporalInferenceControl.java
+++ b/nars_core/nars/control/TemporalInferenceControl.java
@@ -16,9 +16,7 @@ import nars.inference.BudgetFunctions;
 import nars.inference.TemporalRules;
 import nars.io.Symbols;
 import nars.language.CompoundTerm;
-import nars.language.Conjunction;
 import nars.operator.Operation;
-import nars.storage.Bag;
 import nars.storage.LevelBag;
 import nars.storage.Memory;
 import nars.util.Events;
@@ -161,8 +159,8 @@ public class TemporalInferenceControl {
         //multiple versions are necessary, but we do not allow duplicates
         List<Task> removals = new LinkedList<Task>();
         for(Task s : nal.memory.seq_current) {
-            if(CompoundTerm.cloneDeepReplaceIntervals(s.getTerm()).equals(
-                    CompoundTerm.cloneDeepReplaceIntervals(newEvent.getTerm()))) {
+            if(CompoundTerm.replaceIntervals(s.getTerm()).equals(
+                    CompoundTerm.replaceIntervals(newEvent.getTerm()))) {
                     // && //-- new outcommented
                     //s.sentence.stamp.equals(newEvent.sentence.stamp,false,true,true,false) ) {
                 //&& newEvent.sentence.getOccurenceTime()>s.sentence.getOccurenceTime() ) { 

--- a/nars_core/nars/inference/LocalRules.java
+++ b/nars_core/nars/inference/LocalRules.java
@@ -20,14 +20,12 @@
  */
 package nars.inference;
 
-import java.util.Arrays;
 import nars.config.Parameters;
 import nars.util.Events.Answer;
 import nars.util.Events.Unsolved;
 import nars.storage.Memory;
 import nars.control.DerivationContext;
 import nars.entity.BudgetValue;
-import nars.entity.Concept;
 import nars.entity.Sentence;
 import nars.entity.Stamp;
 import nars.entity.Task;
@@ -100,7 +98,7 @@ public class LocalRules {
         }
         return (s1.getRevisible() && 
                 matchingOrder(s1.getTemporalOrder(), s2.getTemporalOrder()) &&
-                CompoundTerm.cloneDeepReplaceIntervals(s1.term).equals(CompoundTerm.cloneDeepReplaceIntervals(s2.term)) && 
+                CompoundTerm.replaceIntervals(s1.term).equals(CompoundTerm.replaceIntervals(s2.term)) &&
                 !Stamp.baseOverlap(s1.stamp.evidentialBase, s2.stamp.evidentialBase));
     }
 

--- a/nars_core/nars/language/CompoundTerm.java
+++ b/nars_core/nars/language/CompoundTerm.java
@@ -157,7 +157,15 @@ public abstract class CompoundTerm extends Term implements Iterable<Term> {
             }
         }
     }
-    
+
+    public static Term replaceIntervals(Term T) {
+        if(T instanceof CompoundTerm) {
+            T=T.cloneDeep(); //we will operate on a copy
+            ReplaceIntervals((CompoundTerm) T);
+        }
+        return T;
+    }
+
     public static Term cloneDeepReplaceIntervals(Term T) {
         T=T.cloneDeep(); //we will operate on a copy
         if(T instanceof CompoundTerm) {
@@ -165,7 +173,8 @@ public abstract class CompoundTerm extends Term implements Iterable<Term> {
         }
         return T;
     }
-    
+
+
     public CompoundTerm transformIndependentVariableToDependentVar(CompoundTerm T) {
         T=T.cloneDeep(); //we will operate on a copy
         int counter = 0;

--- a/nars_lab/nars/lab/testutils/ConceptMonitor.java
+++ b/nars_lab/nars/lab/testutils/ConceptMonitor.java
@@ -8,7 +8,6 @@ import nars.NAR;
 import nars.entity.Concept;
 import nars.entity.Sentence;
 import nars.entity.Task;
-import nars.entity.TruthValue;
 import nars.io.Narsese;
 import nars.io.Symbols;
 import nars.language.CompoundTerm;
@@ -75,8 +74,8 @@ public class ConceptMonitor {
         Term st = stringToTerm(nar, statement);
         if(c != null && st != null) {
             for(Task t : c.executable_preconditions) {
-                if(CompoundTerm.cloneDeepReplaceIntervals(t.getTerm()).equals(
-                        CompoundTerm.cloneDeepReplaceIntervals(st))) {
+                if(CompoundTerm.replaceIntervals(t.getTerm()).equals(
+                        CompoundTerm.replaceIntervals(st))) {
                     return t.sentence;
                 }
             }


### PR DESCRIPTION
By specialization.

We don't have to copy for comparisons and boolean queries.

Seems to be way faster and moves the hotspots to way harder to optimize places.