### PR TITLE
132 cleanup unit test console

### DIFF
--- a/src/main/java/org/opennars/control/ConceptProcessing.java
+++ b/src/main/java/org/opennars/control/ConceptProcessing.java
@@ -601,7 +601,9 @@ public class ConceptProcessing {
                 if(!oper.call(op, nal.memory)) {
                     return false;
                 }
-                System.out.println(t.toStringLong());
+                if (Parameters.DEBUG) {
+                    System.out.println(t.toStringLong());
+                }
                 //this.memory.sequenceTasks = new LevelBag<>(Parameters.SEQUENCE_BAG_LEVELS, Parameters.SEQUENCE_BAG_SIZE);
                 return true;
             }

--- a/src/test/java/org/opennars/core/NALTest.java
+++ b/src/test/java/org/opennars/core/NALTest.java
@@ -40,7 +40,7 @@ public class NALTest  {
 
     static {
         Memory.randomNumber.setSeed(1);
-        Parameters.DEBUG = true;
+        Parameters.DEBUG = false;
         Parameters.TEST_RUNNING = true;
     }
 


### PR DESCRIPTION
ConceptProcessing.java had a System.out that wasn't commented out, so I
put it behind a Parameters.DEBUG conditional as it seems that was being
used elsewhere in the code.


Turn Parameters.DEBUG to false in NALTest
    
abf84d0c saw the introduction of
    
    Parameters.DEBUG = true;
    
In NALTest which then turned on a bunch of verbose logging elsewhere in
the code base.  I switched this to false as it seems unnecessary for
normal test runs.  Alternatively it might be good to change this to be :
    
    Parameters.DEBUG = Boolean.getBoolean("nar.test.debug");
    
But this also has drawbacks as you'd need to ensure that runs before all
other tests, etc...  This is the reason I didn't do it this way.  Simply
changing the value to false seemed the most straightforward way.
    
Addresses opennars/opennars#132
