### PR TITLE
Fix: ConceptProcessing.processJudgment: strongest_target==null case handled cleanly

### DIFF
--- a/src/main/java/org/opennars/control/ConceptProcessing.java
+++ b/src/main/java/org/opennars/control/ConceptProcessing.java
@@ -185,6 +185,10 @@ public class ConceptProcessing {
                                         break;
                                     }
                                 }
+                                
+                                if(strongest_target == null) {
+                                    return;
+                                }
 
                                 final int a = pred_conc.executable_preconditions.size();
 


### PR DESCRIPTION
In cases where there is no eternal belief leading to strongest_target we shouldn't even try adding it to the precondition memory of the target concept. Previously it also didn't happen due to exception, but it's better to not rely on an exception for this, now checking+returning cleanly.