### PR TITLE
Fix: ConceptProcessing.processJudgment: In cases where there is no et…

### DIFF
--- a/src/main/java/org/opennars/control/ConceptProcessing.java
+++ b/src/main/java/org/opennars/control/ConceptProcessing.java
@@ -194,12 +194,15 @@ public class ConceptProcessing {
             }
 
             Task strongest_target = null; //beliefs.get(0);
-            //get the first eternal:
+            //get the first eternal. the highest confident one (due to the sorted order):
             for(final Task t : concept.beliefs) {
                 if(t.sentence.isEternal()) {
                     strongest_target = t;
                     break;
                 }
+            }
+            if(strongest_target == null) {
+                return;
             }
 
             //at first we have to remove the last one with same content from table


### PR DESCRIPTION
…ermal belief leading to strongest_target we shouldn't even try adding it to the precondition memory of the target concept. Previously it also didn't happen due to exception, but it's better to not rely on an exception for this especially now where they are gone, now checking+returning cleanly.