### PR TITLE
Interval collapse (&/,a,+1,+1) to (&/,a,+2) with test case.

### DIFF
--- a/src/main/java/org/opennars/entity/Sentence.java
+++ b/src/main/java/org/opennars/entity/Sentence.java
@@ -137,18 +137,6 @@ public class Sentence<T extends Term> implements Cloneable, Serializable {
                     truth.setConfidence(0.0f);
                 if (((Statement) _content).getPredicate().hasVarIndep() && !((Statement) _content).getSubject().hasVarIndep())
                     truth.setConfidence(0.0f); //TODO:
-                if (_content.getTemporalOrder() != TemporalRules.ORDER_NONE &&
-                    _content.getTemporalOrder() != TemporalRules.ORDER_INVALID) { //do not allow =/> statements without conjunction on left
-                    if ((((Statement) _content).getSubject() instanceof Conjunction)) {
-                        final Conjunction conj = (Conjunction) ((Statement) _content).getSubject();
-                        if (!conj.isSpatial && conj.getTemporalOrder() == TemporalRules.ORDER_FORWARD) {
-                            //when the last two are intervals, its not valid
-                            if (conj.term[conj.term.length - 1] instanceof Interval && conj.term[conj.term.length - 2] instanceof Interval) {
-                                truth.setConfidence(0.0f);
-                            }
-                        }
-                    }
-                }
             } else if (_content instanceof Interval && punctuation != Symbols.TERM_NORMALIZING_WORKAROUND_MARK) {
                 truth.setConfidence(0.0f); //do it that way for now, because else further inference is interrupted.
                 if (Parameters.DEBUG)

--- a/src/main/java/org/opennars/language/Conjunction.java
+++ b/src/main/java/org/opennars/language/Conjunction.java
@@ -187,6 +187,33 @@ public class Conjunction extends CompoundTerm {
     }
     
     /**
+     * @param components The components
+     * @return The components sequence with summed intervals
+     * for transforming (&/,a,+1,+1) to (&/,a,+2)
+     */
+    public static Term[] collapseIntervals(Term[] components) {
+        List<Term> ret = new ArrayList<Term>();
+        for(int i=0;i<components.length;) {
+            if(!(components[i] instanceof Interval)) {
+                ret.add(components[i]);
+                i++;
+            }
+            else {
+                //add up next ones:
+                long ival = ((Interval)components[i]).time;
+                int k=1;
+                while(i+k<components.length && components[i+k] instanceof Interval) {
+                    ival += ((Interval)components[i+k]).time;
+                    k++;
+                }
+                ret.add(new Interval(ival));
+                i+=k;
+            }
+        }
+        return ret.toArray(new Term[0]);
+    }
+    
+    /**
      * Try to make a new compound from a list of term. Called by StringParser.
      *
      * @param temporalOrder The temporal order among term
@@ -208,7 +235,7 @@ public class Conjunction extends CompoundTerm {
         }                         // special case: single component
         
         if (temporalOrder == TemporalRules.ORDER_FORWARD) {
-            final Term[] newArgList = spatial ? argList : flatten(argList, temporalOrder, spatial);
+            final Term[] newArgList = spatial ? argList : collapseIntervals(flatten(argList, temporalOrder, spatial));
             
             if(newArgList.length == 1) {
                 return newArgList[0];

--- a/src/test/resources/nal/single_step/nal7.36.nal
+++ b/src/test/resources/nal/single_step/nal7.36.nal
@@ -1,0 +1,9 @@
+'********** deduction with interval summation
+
+<(&/, a, +1) =/> b>.
+<(&/, b, +1) =/> c>.
+  
+10
+
+''outputMustContain('<(&/,a,+2) =/> c>. %1.00;0.81%')
+


### PR DESCRIPTION
Example:
<(&/, a, +1) =/> b>.
<(&/, b, +1) =/> c>.
|-
<(&/,a,+2) =/> c>. %1.00;0.81%