### PR TITLE
Fix: NarseseParser: Handle exception in Shell and GUI properly as in …

### DIFF
--- a/src/main/java/org/opennars/main/Shell.java
+++ b/src/main/java/org/opennars/main/Shell.java
@@ -74,8 +74,17 @@ public class Shell {
         {
             try {
                 final String line=bufIn.readLine();
-                if(line!=null)
-                    nar.addInput(line);
+                if(line!=null) {
+                    try {
+                        nar.addInput(line);
+                    } catch(IllegalStateException ex) {
+                        if(Parameters.DEBUG) {
+                            throw new IllegalStateException("error parsing:" +line, ex);
+                        }
+                        System.out.println("parsing error");
+                    }
+                }
+                
             } catch (final IOException e) {
                 throw new IllegalStateException("Could not read line.", e);
             }

--- a/src/main/java/org/opennars/main/Shell.java
+++ b/src/main/java/org/opennars/main/Shell.java
@@ -77,7 +77,7 @@ public class Shell {
                 if(line!=null) {
                     try {
                         nar.addInput(line);
-                    } catch(IllegalStateException ex) {
+                    } catch(Exception ex) {
                         if(Parameters.DEBUG) {
                             throw new IllegalStateException("error parsing:" +line, ex);
                         }


### PR DESCRIPTION
…v1.6.5, so that the system does not crash.