### PR TITLE
Update deploy.sh

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -2,7 +2,7 @@
 if [ ! -z "$TRAVIS_TAG" ]
 then
     echo "on a tag -> set pom.xml <version> to $TRAVIS_TAG"
-    mvn --settings .travis/settings.xml org.opennars.opennars:versions-maven-plugin:2.1:set -DnewVersion=$TRAVIS_TAG 1>/dev/null 2>/dev/null
+    mvn --settings .travis/settings.xml https://oss.sonatype.org/content/repositories/snapshots/org/opennars/opennars/:versions-maven-plugin:2.1:set -DnewVersion=$TRAVIS_TAG 1>/dev/null 2>/dev/null
 else
     echo "not on a tag -> keep snapshot version in pom.xml"
 fi


### PR DESCRIPTION
Further change to  mvn repo path to try and resolve Travis build error below:

skipping a deployment with the script provider because this repo's name does not match one specified in .travis.yml's deploy.on.repo: https://oss.sonatype.org/content/repositories/snapshots/org/opennars/opennars/