### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,6 @@ deploy:
     script: .travis/deploy.sh
     skip_cleanup: true
     on:
-      repo: https://oss.sonatype.org/content/repositories/snapshots/org/opennars/opennars/
+      repo: opennars/opennars
       branch: master
       jdk: oraclejdk8


### PR DESCRIPTION
Updated repo name as potential fix to: 
Skipping a deployment with the script provider because this repo's name does not match one specified in .travis.yml's deploy.on.repo

from: https://oss.sonatype.org/content/repositories/snapshots/org/opennars/opennars/
to: opennars/opennars