### PR TITLE
Fix: Serialize task: Don't serialize derivation context or even entir…

### DIFF
--- a/src/main/java/org/opennars/main/NarNode.java
+++ b/src/main/java/org/opennars/main/NarNode.java
@@ -261,6 +261,7 @@ public class NarNode implements EventObserver  {
             NoSuchMethodException, SAXException, ClassNotFoundException, IllegalAccessException, ParseException {
         if((args.length-3) % 5 != 0) { //args length check, it has to be 3+5*k, with k in N0
             System.out.println("expected arguments: file cycles listenPort targetIP1 targetPort1 prioThres1 mustContainTerm1 sendInput1 ... targetIPN targetPortN prioThresN mustContainTermN sendInputN");
+            System.out.println("Here, since file and cycles are not always used, they can be null too, example: null null 64001 127.0.0.1 64002 0.5 null True");
             System.exit(0);
         }
         int nar1port = Integer.parseInt(args[2]);

--- a/src/main/java/org/opennars/main/NarNode.java
+++ b/src/main/java/org/opennars/main/NarNode.java
@@ -228,7 +228,7 @@ public class NarNode implements EventObserver  {
      * @throws ClassNotFoundException 
      */
     private Object receiveObject() throws IOException, ClassNotFoundException {
-        byte[] recBytes = new byte[100000];
+        byte[] recBytes = new byte[1000000];
         DatagramPacket packet = new DatagramPacket(recBytes, recBytes.length);
         receiveSocket.receive(packet);
         ObjectInputStream iStream = new ObjectInputStream(new ByteArrayInputStream(recBytes));

--- a/src/main/java/org/opennars/operator/Operator.java
+++ b/src/main/java/org/opennars/operator/Operator.java
@@ -47,11 +47,8 @@ public abstract class Operator extends Term implements Plugin {
             throw new IllegalStateException("Operator name needs ^ prefix");
     }
 
-    public Nar nar;
-    
     @Override
     public boolean setEnabled(final Nar n, final boolean enabled) {
-        this.nar = n;
         this.executionConfidence = n.narParameters.DEFAULT_JUDGMENT_CONFIDENCE;
         return true;
     }        

--- a/src/main/java/org/opennars/operator/mental/Consider.java
+++ b/src/main/java/org/opennars/operator/mental/Consider.java
@@ -53,7 +53,7 @@ public class Consider extends Operator {
         
         final Concept concept = memory.conceptualize(Consider.budgetMentalConcept(operation), term);
         
-        final DerivationContext cont = new DerivationContext(memory, nar.narParameters, time);
+        final DerivationContext cont = new DerivationContext(memory, memory.narParameters, time);
         cont.setCurrentConcept(concept);
         GeneralInferenceControl.fireConcept(cont, 1);
         


### PR DESCRIPTION
…e Nar objects in operators just because ^believe is part of a term of the task. So The nar member was removed from operator, and also the DerivationContext member in Anticipate.