### PR TITLE
ranking by var-complexity for better decision making

### DIFF
--- a/src/main/java/org/opennars/control/concept/ProcessGoal.java
+++ b/src/main/java/org/opennars/control/concept/ProcessGoal.java
@@ -158,7 +158,7 @@ public class ProcessGoal {
         }
         bestReactionForGoal(concept, nal, projectedGoal, task);
         questionFromGoal(task, nal);
-        concept.addToTable(task, false, concept.desires, nal.narParameters.CONCEPT_GOALS_MAX, Events.ConceptGoalAdd.class, Events.ConceptGoalRemove.class);
+        concept.addToTable(task, false, false, concept.desires, nal.narParameters.CONCEPT_GOALS_MAX, Events.ConceptGoalAdd.class, Events.ConceptGoalRemove.class);
         InternalExperience.InternalExperienceFromTask(concept.memory, task, false, nal.time);
         if(!(task.sentence.getTerm() instanceof Operation)) {
             return;

--- a/src/main/java/org/opennars/control/concept/ProcessJudgment.java
+++ b/src/main/java/org/opennars/control/concept/ProcessJudgment.java
@@ -101,7 +101,7 @@ public class ProcessJudgment {
         for (int i = 0; i < nng; i++) {
             trySolution(judg, concept.desires.get(i), nal, true);
         }
-        concept.addToTable(task, false, concept.beliefs, concept.memory.narParameters.CONCEPT_BELIEFS_MAX, Events.ConceptBeliefAdd.class, Events.ConceptBeliefRemove.class);
+        concept.addToTable(task, false, false, concept.beliefs, concept.memory.narParameters.CONCEPT_BELIEFS_MAX, Events.ConceptBeliefAdd.class, Events.ConceptBeliefRemove.class);
     }
 
     /**
@@ -216,7 +216,7 @@ public class ProcessJudgment {
                     table.remove(i_delete);
                 }
                 //this way the strongest confident result of this content is put into table but the table ranked according to truth expectation
-                target_concept.addToTable(strongest_target.get(), true, table, target_concept.memory.narParameters.CONCEPT_BELIEFS_MAX, Events.EnactableExplainationAdd.class, Events.EnactableExplainationRemove.class);
+                target_concept.addToTable(strongest_target.get(), true, true, table, target_concept.memory.narParameters.CONCEPT_BELIEFS_MAX, Events.EnactableExplainationAdd.class, Events.EnactableExplainationRemove.class);
             }
         }
     }

--- a/src/main/java/org/opennars/entity/Concept.java
+++ b/src/main/java/org/opennars/entity/Concept.java
@@ -167,12 +167,12 @@ public class Concept extends Item<Term> implements Serializable {
 
 
 
-    public void addToTable(final Task task, final boolean rankTruthExpectation, final List<Task> table, final int max, final Class eventAdd, final Class eventRemove, final Object... extraEventArguments) {
+    public void addToTable(final Task task, final boolean rankTruthExpectation, final boolean takeVarIntoAccount, final List<Task> table, final int max, final Class eventAdd, final Class eventRemove, final Object... extraEventArguments) {
         
         final int preSize = table.size();
         final Task removedT;
         Sentence removed = null;
-        removedT = addToTable(task, table, max, rankTruthExpectation);
+        removedT = addToTable(task, table, max, rankTruthExpectation, takeVarIntoAccount);
         if(removedT != null) {
             removed=removedT.sentence;
         }
@@ -238,14 +238,14 @@ public class Concept extends Item<Term> implements Serializable {
      * @param capacity The capacity of the table
      * @return whether table was modified
      */
-    public static Task addToTable(final Task newTask, final List<Task> table, final int capacity, final boolean rankTruthExpectation) {
+    public static Task addToTable(final Task newTask, final List<Task> table, final int capacity, final boolean rankTruthExpectation, final boolean takeVarIntoAccount) {
         final Sentence newSentence = newTask.sentence;
-        final float rank1 = rankBelief(newSentence, rankTruthExpectation);    // for the new isBelief
+        final float rank1 = rankBelief(newSentence, rankTruthExpectation, takeVarIntoAccount);    // for the new isBelief
         float rank2;        
         int i;
         for (i = 0; i < table.size(); i++) {
             final Sentence judgment2 = table.get(i).sentence;
-            rank2 = rankBelief(judgment2, rankTruthExpectation);
+            rank2 = rankBelief(judgment2, rankTruthExpectation, takeVarIntoAccount);
             if (rank1 >= rank2) {
                 if (newSentence.truth.equals(judgment2.truth) && newSentence.stamp.equals(judgment2.stamp,false,true,true)) {
                     //System.out.println(" ---------- Equivalent Belief: " + newSentence + " == " + judgment2);

--- a/src/main/java/org/opennars/inference/BudgetFunctions.java
+++ b/src/main/java/org/opennars/inference/BudgetFunctions.java
@@ -24,7 +24,9 @@
 package org.opennars.inference;
 
 import org.opennars.entity.*;
+import org.opennars.language.CompoundTerm;
 import org.opennars.language.Term;
+import org.opennars.language.Variable;
 import org.opennars.storage.Memory;
 
 import static java.lang.Math.*;
@@ -62,13 +64,29 @@ public final class BudgetFunctions extends UtilityFunctions {
     public final static float rankBelief(final Sentence judg, final boolean rankTruthExpectation, final boolean takeVarIntoAccount) {
         if(rankTruthExpectation) {
             float base = 1.05f;
-            
-            float complexity = takeVarIntoAccount && judg.term.hasVar() ? 1 : 0;
+
+            float complexity = takeVarIntoAccount && judg.term.hasVar() ? countNumberOfVars(judg.term) : 0;
             return judg.getTruth().getExpectation() / (float)Math.pow(base, complexity);
         }
         final float confidence = judg.truth.getConfidence();
         //final float originality = judg.stamp.getOriginality();
         return confidence; //or(confidence, originality);
+    }
+
+    private static int countNumberOfVars(final Term term) {
+        if (term instanceof Variable) {
+            return 1;
+        }
+        else if(term instanceof CompoundTerm) {
+            int count = 0;
+
+            CompoundTerm compoundTerm = (CompoundTerm)term;
+            for(final Term iChild : compoundTerm.term) {
+                count += countNumberOfVars(iChild);
+            }
+            return count;
+        }
+        return 0;
     }
 
 

--- a/src/main/java/org/opennars/inference/BudgetFunctions.java
+++ b/src/main/java/org/opennars/inference/BudgetFunctions.java
@@ -59,9 +59,12 @@ public final class BudgetFunctions extends UtilityFunctions {
      * @param judg The judgment to be ranked
      * @return The rank of the judgment, according to truth value only
      */
-    public final static float rankBelief(final Sentence judg, final boolean rankTruthExpectation) {        
+    public final static float rankBelief(final Sentence judg, final boolean rankTruthExpectation, final boolean takeVarIntoAccount) {
         if(rankTruthExpectation) {
-            return judg.getTruth().getExpectation();
+            float base = 1.05f;
+            
+            float complexity = takeVarIntoAccount && judg.term.hasVar() ? 1 : 0;
+            return judg.getTruth().getExpectation() / (float)Math.pow(base, complexity);
         }
         final float confidence = judg.truth.getConfidence();
         //final float originality = judg.stamp.getOriginality();


### PR DESCRIPTION
A problem in my pong tests were that it tried to make decisions where the term contained a variable in the critical precondition

ex:
$0,3440;0,0347;0,6623$ <(&/,<{#1} --> [ballBatPos]>,+15285,(^up,{SELF}),+3096) =/> <{SELF1} --> [good]>>. 
"go always up and you will be good"

Which is misleading and an overgeneralization.

This PR tries to prevent this by biasing the decision tables to terms without vars