### PR TITLE
Anticpation: Computation of urgency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.opennars</groupId>
     <artifactId>opennars</artifactId>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>3.0.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>

--- a/src/main/java/org/opennars/control/concept/ProcessAnticipation.java
+++ b/src/main/java/org/opennars/control/concept/ProcessAnticipation.java
@@ -55,7 +55,7 @@ import static org.opennars.inference.UtilityFunctions.w2c;
 public class ProcessAnticipation {
 
     public static void anticipate(final DerivationContext nal, final Sentence mainSentence, final BudgetValue budget, 
-            final long mintime, final long maxtime, final float priority, Map<Term,Term> substitution) {
+            final long mintime, final long maxtime, final float urgency, Map<Term,Term> substitution) {
         //derivation was successful and it was a judgment event
         final Stamp stamp = new Stamp(nal.time, nal.memory);
         stamp.setOccurrenceTime(Stamp.ETERNAL);
@@ -71,12 +71,12 @@ public class ProcessAnticipation {
         if(c != null /*&& mintime > nal.memory.time()*/ && c.observable && (mainSentence.getTerm() instanceof Implication || mainSentence.getTerm() instanceof Equivalence) && 
                 mainSentence.getTerm().getTemporalOrder() == TemporalRules.ORDER_FORWARD) {
             Concept.AnticipationEntry toDelete = null;
-            Concept.AnticipationEntry toInsert = new Concept.AnticipationEntry(priority, t, mintime, maxtime);
+            Concept.AnticipationEntry toInsert = new Concept.AnticipationEntry(urgency, t, mintime, maxtime);
             boolean fullCapacity = c.anticipations.size() >= nal.narParameters.ANTICIPATIONS_PER_CONCEPT_MAX;
             //choose an element to replace with the new, in case that we are already at full capacity
             if(fullCapacity) {
                 for(Concept.AnticipationEntry entry : c.anticipations) {
-                    if(priority > entry.negConfirmationPriority /*|| t.getPriority() > c.negConfirmation.getPriority() */) {
+                    if(urgency > entry.negConfirmationPriority /*|| t.getPriority() > c.negConfirmation.getPriority() */) {
                         //prefer to replace one that is more far in the future, takes longer to be disappointed about
                         if(toDelete == null || entry.negConfirm_abort_maxtime > toDelete.negConfirm_abort_maxtime) {
                             toDelete = entry;

--- a/src/main/java/org/opennars/control/concept/ProcessGoal.java
+++ b/src/main/java/org/opennars/control/concept/ProcessGoal.java
@@ -258,6 +258,7 @@ public class ProcessGoal {
         public Task executable_precond = null;
         public long mintime = -1;
         public long maxtime = -1;
+        public float timeOffset;
         public Map<Term,Term> substitution;
     }
 
@@ -315,7 +316,10 @@ public class ProcessGoal {
                 }
                 System.out.println("Executed based on: " + bestOpWithMeta.executable_precond);
                 for(ExecutablePrecondition precon : anticipationsToMake.get(bestOpWithMeta.bestop)) {
-                    ProcessAnticipation.anticipate(nal, precon.executable_precond.sentence, precon.executable_precond.budget, precon.mintime, precon.maxtime, 2, precon.substitution);
+                    float distance = precon.timeOffset - nal.time.time();
+                    float urgency = 2.0f + 1.0f/distance;
+
+                    ProcessAnticipation.anticipate(nal, precon.executable_precond.sentence, precon.executable_precond.budget, precon.mintime, precon.maxtime, urgency, precon.substitution);
                 }
                 return; //don't try the other table as a specific solution was already used
             }
@@ -355,12 +359,12 @@ public class ProcessGoal {
                 for(final Task p : concept.memory.seq_current) {
                     Map<Term,Term> subs = new LinkedHashMap<>();
                     if(p.sentence.isJudgment() && !p.sentence.isEternal() && p.sentence.getOccurenceTime() > newesttime && p.sentence.getOccurenceTime() <= nal.time.time()) {
-                        boolean preconditionMatches = Variables.findSubstitute(nal.memory.randomNumber, Symbols.VAR_INDEPENDENT, 
-                                    CompoundTerm.replaceIntervals(precondition), 
-                                    CompoundTerm.replaceIntervals(p.sentence.term), subs, new LinkedHashMap<>());
-                        boolean conclusionMatches = Variables.findSubstitute(nal.memory.randomNumber, Symbols.VAR_INDEPENDENT, 
-                                    CompoundTerm.replaceIntervals(((Implication) t.getTerm()).getPredicate()), 
-                                    CompoundTerm.replaceIntervals(projectedGoal.getTerm()), subs, new LinkedHashMap<>());
+                        boolean preconditionMatches = Variables.findSubstitute(nal.memory.randomNumber, Symbols.VAR_INDEPENDENT,
+                            CompoundTerm.replaceIntervals(precondition),
+                            CompoundTerm.replaceIntervals(p.sentence.term), subs, new LinkedHashMap<>());
+                        boolean conclusionMatches = Variables.findSubstitute(nal.memory.randomNumber, Symbols.VAR_INDEPENDENT,
+                            CompoundTerm.replaceIntervals(((Implication) t.getTerm()).getPredicate()),
+                            CompoundTerm.replaceIntervals(projectedGoal.getTerm()), subs, new LinkedHashMap<>());
                         if(preconditionMatches && conclusionMatches){
                             newesttime = p.sentence.getOccurenceTime();
                             //Apply interval penalty for interval differences in the precondition
@@ -381,8 +385,8 @@ public class ProcessGoal {
             final TruthValue Hyp = t.sentence.truth;
             //overlap will almost never happen, but to make sure
             if(Stamp.baseOverlap(projectedGoal.stamp, t.sentence.stamp) ||
-               Stamp.baseOverlap(bestsofar.sentence.stamp, t.sentence.stamp) ||
-               Stamp.baseOverlap(projectedGoal.stamp, bestsofar.sentence.stamp)) {
+                Stamp.baseOverlap(bestsofar.sentence.stamp, t.sentence.stamp) ||
+                Stamp.baseOverlap(projectedGoal.stamp, bestsofar.sentence.stamp)) {
                 continue;
             }
             //and the truth of the precondition:
@@ -407,11 +411,12 @@ public class ProcessGoal {
                 result.substitution = subsBest;
                 result.mintime = mintime;
                 result.maxtime = maxtime;
+                result.timeOffset = timeOffset;
                 if(anticipationsToMake.get(result.bestop) == null) {
                     anticipationsToMake.put(result.bestop, new ArrayList<ExecutablePrecondition>());
                 }
                 anticipationsToMake.get(result.bestop).add(result);
-            }  
+            }
         }
         return result;
     }

--- a/src/main/java/org/opennars/main/Nar.java
+++ b/src/main/java/org/opennars/main/Nar.java
@@ -84,7 +84,7 @@ public class Nar extends SensoryChannel implements Reasoner, Serializable, Runna
     /**
      * The information about the version of the project
      */
-    public static final String VERSION = "v3.0.2";
+    public static final String VERSION = "v3.0.3";
 
     /**
      * Name of the reasoner of the project


### PR DESCRIPTION
* compute urgency by time difference
Fixes the issue that it fills up the anticipation table with the same priorities