### PR TITLE
Update: bump travis build java sdk to 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 
 sudo: false
 jdk:
-  - oraclejdk8
+  - oraclejdk11
 env:
   - CODACY_PROJECT_TOKEN=636acc26006042628c9ec9391472a1c6
   


### PR DESCRIPTION
Necessary because it doesn't build anymore