### PR TITLE
Update: ProcessAnticipation: Don't require confirming tasks to be inp…

### DIFF
--- a/src/main/java/org/opennars/control/concept/ProcessGoal.java
+++ b/src/main/java/org/opennars/control/concept/ProcessGoal.java
@@ -265,6 +265,7 @@ public class ProcessGoal {
         public long maxtime = -1;
         public float timeOffset;
         public Map<Term,Term> substitution;
+        public Stamp prediction_stamp = null;
     }
 
     /**
@@ -324,7 +325,7 @@ public class ProcessGoal {
                     float distance = precon.timeOffset - nal.time.time();
                     float urgency = 2.0f + 1.0f/distance;
 
-                    ProcessAnticipation.anticipate(nal, precon.executable_precond.sentence, precon.executable_precond.budget, precon.mintime, precon.maxtime, urgency, precon.substitution);
+                    ProcessAnticipation.anticipate(nal, precon.prediction_stamp, precon.executable_precond.sentence, precon.executable_precond.budget, precon.mintime, precon.maxtime, urgency, precon.substitution);
                 }
                 return; //don't try the other table as a specific solution was already used
             }
@@ -419,6 +420,7 @@ public class ProcessGoal {
                 result.mintime = mintime;
                 result.maxtime = maxtime;
                 result.timeOffset = timeOffset;
+                result.prediction_stamp = new Stamp(new Stamp(projectedGoal.stamp, t.sentence.stamp, nal.time.time(), nal.narParameters),bestsofar.sentence.stamp, nal.time.time(), nal.narParameters);
                 if(anticipationsToMake.get(result.bestop) == null) {
                     anticipationsToMake.put(result.bestop, new ArrayList<ExecutablePrecondition>());
                 }

--- a/src/main/java/org/opennars/control/concept/ProcessTask.java
+++ b/src/main/java/org/opennars/control/concept/ProcessTask.java
@@ -55,7 +55,6 @@ public class ProcessTask {
     // called in Memory.localInference only, for both derived and input tasks
     public static boolean processTask(final Concept concept, final DerivationContext nal, final Task task, Timable time) {
         synchronized(concept) {
-            concept.observable |= task.isInput();
             final char type = task.sentence.punctuation;
             switch (type) {
                 case Symbols.JUDGMENT_MARK:

--- a/src/main/java/org/opennars/entity/Concept.java
+++ b/src/main/java/org/opennars/entity/Concept.java
@@ -118,8 +118,6 @@ public class Concept extends Item<Term> implements Serializable {
     //so that revision can decide whether to use the new or old term
     //based on which intervals are closer to the average
     public final List<Float> recent_intervals = new ArrayList<>();
-
-    public boolean observable = false; //whether it received a "native" input task
     public boolean allowBabbling = true; //for operations, becomes false if sufficiently
                                          //confident, used procedure knowledge  exists.
 
@@ -303,13 +301,15 @@ public class Concept extends Item<Term> implements Serializable {
     public static class AnticipationEntry implements Serializable {
         public float negConfirmationPriority = 0.0f;
         public Task negConfirmation = null;
+        public Stamp predictionStamp = null;
         public long negConfirm_abort_mintime = 0;
         public long negConfirm_abort_maxtime = 0;
-        public AnticipationEntry(float negConfirmationPriority, Task negConfirmation, long negConfirm_abort_mintime, long negConfirm_abort_maxtime) {
+        public AnticipationEntry(float negConfirmationPriority, Task negConfirmation, long negConfirm_abort_mintime, long negConfirm_abort_maxtime, Stamp predictionStamp) {
             this.negConfirmationPriority = negConfirmationPriority;
             this.negConfirmation = negConfirmation;
             this.negConfirm_abort_mintime = negConfirm_abort_mintime;
             this.negConfirm_abort_maxtime = negConfirm_abort_maxtime;
+            this.predictionStamp = predictionStamp;
         }
     }
     public List<AnticipationEntry> anticipations = new ArrayList<>();

--- a/src/main/java/org/opennars/inference/SyllogisticRules.java
+++ b/src/main/java/org/opennars/inference/SyllogisticRules.java
@@ -680,7 +680,7 @@ public final class SyllogisticRules {
         if(!nal.evidentalOverlap && ret != null && ret.size() > 0 && predictedEvent && taskSentence.isJudgment() && truth != null && 
             truth.getExpectation() > nal.narParameters.DEFAULT_CONFIRMATION_EXPECTATION && !premise1Sentence.stamp.alreadyAnticipatedNegConfirmation) {
             premise1Sentence.stamp.alreadyAnticipatedNegConfirmation = true;
-            ProcessAnticipation.anticipate(nal, premise1Sentence, budget, mintime, maxtime, 1, new LinkedHashMap<Term,Term>());
+            ProcessAnticipation.anticipate(nal, nal.getTheNewStamp(), premise1Sentence, budget, mintime, maxtime, 1, new LinkedHashMap<Term,Term>());
         }
     }
 


### PR DESCRIPTION
…ut and the concept the anticipation is about to be observable. Instead, let anticipation happen and let it confirm by tasks that have no evidental overlap with the prediction. (not only input)

Related discussion: https://groups.google.com/forum/#!topic/open-nars/U5KPD363Ay0