### PR TITLE
Radical control

### DIFF
--- a/src/main/java/org/opennars/control/DerivationContext.java
+++ b/src/main/java/org/opennars/control/DerivationContext.java
@@ -219,7 +219,7 @@ public class DerivationContext {
             newSentence.producedByTemporalInduction=temporalInduction;
             Task newTask = new Task(newSentence, newBudget, getCurrentBelief());
 
-            if (newTask!=null) {
+            if (newTask!=null && !(!newTask.sentence.isEternal() && (newTask.sentence.term instanceof Implication || newTask.sentence.term instanceof Equivalence))) {
                 final boolean added = derivedTask(newTask, false, false, overlapAllowed, addToMemory);
                 if(added) {
                     ret.add(newTask);

--- a/src/main/java/org/opennars/control/GeneralInferenceControl.java
+++ b/src/main/java/org/opennars/control/GeneralInferenceControl.java
@@ -24,13 +24,11 @@
 package org.opennars.control;
 
 import org.opennars.control.concept.ProcessAnticipation;
-import org.opennars.control.concept.ProcessGoal;
 import org.opennars.entity.Concept;
 import org.opennars.entity.Task;
 import org.opennars.entity.TermLink;
 import org.opennars.inference.BudgetFunctions;
 import org.opennars.inference.RuleTables;
-import org.opennars.interfaces.Timable;
 import org.opennars.io.events.Events;
 import org.opennars.main.Nar;
 import org.opennars.main.Parameters;
@@ -115,10 +113,10 @@ public class GeneralInferenceControl {
         }
         if (nal.currentTaskLink.type == TermLink.TRANSFORM) {
             nal.setCurrentBelief(null);
-            //TermLink tasklink_as_termlink = new TermLink(nal.currentTaskLink.getTerm(), TermLink.TRANSFORM, nal.getCurrentTaskLink().index);
-            //if(nal.currentTaskLink.novel(tasklink_as_termlink, nal.memory.time(), true)) { //then record yourself, but also here novelty counts
+            TermLink tasklink_as_termlink = new TermLink(nal.currentTaskLink.getTerm(), TermLink.TRANSFORM, nal.getCurrentTaskLink().index);
+            if(nal.currentTaskLink.novel(tasklink_as_termlink, nal.time.time(), nal.narParameters)) { //then record yourself, but also here novelty counts
                 RuleTables.transformTask(nal.currentTaskLink, nal); // to turn this into structural inference as below?
-            //}
+            }
         } else {            
             while (termLinks > 0) {
                 final TermLink termLink = nal.currentConcept.selectTermLink(nal.currentTaskLink, nal.time.time(), nal.narParameters);

--- a/src/main/java/org/opennars/control/TemporalInferenceControl.java
+++ b/src/main/java/org/opennars/control/TemporalInferenceControl.java
@@ -43,7 +43,7 @@ import java.util.Set;
  * @author Patrick Hammer
  */
 public class TemporalInferenceControl {
-    public static List<Task> proceedWithTemporalInduction(final Sentence newEvent, final Sentence stmLast, final Task controllerTask, final DerivationContext nal, final boolean SucceedingEventsInduction, final boolean addToMemory, final boolean allowSequence) {
+    public static List<Task> proceedWithTemporalInduction(final Sentence newEvent, final Sentence stmLast, final Task controllerTask, final DerivationContext nal, final boolean SucceedingEventsInduction, final boolean addToMemory, final boolean allowSequence, boolean addToSequenceTasks) {
         
         if(SucceedingEventsInduction && !controllerTask.isElemOfSequenceBuffer()) { //todo refine, add directbool in task
             return null;
@@ -67,7 +67,7 @@ public class TemporalInferenceControl {
         final Sentence currentBelief = newEvent;
 
         //if(newEvent.getPriority()>Parameters.TEMPORAL_INDUCTION_MIN_PRIORITY)
-        return TemporalRules.temporalInduction(currentBelief, previousBelief, nal, SucceedingEventsInduction, addToMemory, allowSequence);
+        return TemporalRules.temporalInduction(currentBelief, previousBelief, nal, SucceedingEventsInduction, addToMemory, allowSequence, addToSequenceTasks);
     }
 
     public static boolean eventInference(final Task newEvent, final DerivationContext nal) {
@@ -98,7 +98,7 @@ public class TemporalInferenceControl {
                     continue;
                 }
                 already_attempted.add(takeout);
-                proceedWithTemporalInduction(newEvent.sentence, takeout.sentence, newEvent, nal, true, true, true);
+                proceedWithTemporalInduction(newEvent.sentence, takeout.sentence, newEvent, nal, true, false, true, true);
                 nal.memory.seq_current.putBack(takeout, nal.memory.cycles(nal.memory.narParameters.EVENT_FORGET_DURATIONS), nal.memory);
             }
         }
@@ -140,10 +140,10 @@ public class TemporalInferenceControl {
                             System.out.println("analyze case in TemporalInferenceControl!");
                             continue;
                         }
-                        final List<Task> seq_op = proceedWithTemporalInduction(Toperation.sentence, takeout.sentence, nal.memory.lastDecision, nal, true, false, true);
+                        final List<Task> seq_op = proceedWithTemporalInduction(Toperation.sentence, takeout.sentence, nal.memory.lastDecision, nal, true, false, true, false);
                         for(final Task t : seq_op) {
                             if(!t.sentence.isEternal()) { //TODO do not return the eternal here probably..;
-                                final List<Task> res = proceedWithTemporalInduction(newEvent.sentence, t.sentence, newEvent, nal, true, true, false); //only =/> </> ..
+                                final List<Task> res = proceedWithTemporalInduction(newEvent.sentence, t.sentence, newEvent, nal, true, true, false, false); //only =/> </> ..
                                 /*DEBUG: for(Task seq_op_cons : res) {
                                     System.out.println(seq_op_cons.toString());
                                 }*/

--- a/src/main/java/org/opennars/control/concept/ProcessAnticipation.java
+++ b/src/main/java/org/opennars/control/concept/ProcessAnticipation.java
@@ -54,7 +54,7 @@ import static org.opennars.inference.UtilityFunctions.w2c;
  */
 public class ProcessAnticipation {
 
-    public static void anticipate(final DerivationContext nal, Stamp predictionStamp, final Sentence mainSentence, final BudgetValue budget, 
+    public static void anticipate(final DerivationContext nal, final Sentence mainSentence, final BudgetValue budget, 
             final long mintime, final long maxtime, final float urgency, Map<Term,Term> substitution) {
         //derivation was successful and it was a judgment event
         final Stamp stamp = new Stamp(nal.time, nal.memory);
@@ -68,10 +68,10 @@ public class ProcessAnticipation {
         final Task t = new Task(s, new BudgetValue(0.99f,0.1f,0.1f, nal.narParameters), Task.EnumType.DERIVED); //Budget for one-time processing
         Term specificAnticipationTerm = ((CompoundTerm)((Statement) mainSentence.term).getPredicate()).applySubstitute(substitution);
         final Concept c = nal.memory.concept(specificAnticipationTerm); //put into consequence concept
-        if(c != null /*&& mintime > nal.memory.time() && c.observable*/ && (mainSentence.getTerm() instanceof Implication || mainSentence.getTerm() instanceof Equivalence) && 
+        if(c != null /*&& mintime > nal.memory.time()*/ && c.observable && (mainSentence.getTerm() instanceof Implication || mainSentence.getTerm() instanceof Equivalence) && 
                 mainSentence.getTerm().getTemporalOrder() == TemporalRules.ORDER_FORWARD) {
             Concept.AnticipationEntry toDelete = null;
-            Concept.AnticipationEntry toInsert = new Concept.AnticipationEntry(urgency, t, mintime, maxtime, predictionStamp);
+            Concept.AnticipationEntry toInsert = new Concept.AnticipationEntry(urgency, t, mintime, maxtime);
             boolean fullCapacity = c.anticipations.size() >= nal.narParameters.ANTICIPATIONS_PER_CONCEPT_MAX;
             //choose an element to replace with the new, in case that we are already at full capacity
             if(fullCapacity) {
@@ -213,11 +213,11 @@ public class ProcessAnticipation {
      * @param nal The derivation context
      */
     public static void confirmAnticipation(Task task, Concept concept, final DerivationContext nal) {
-        final boolean satisfiesAnticipation = /*task.isInput() && */!task.sentence.isEternal();
+        final boolean satisfiesAnticipation = task.isInput() && !task.sentence.isEternal();
         final boolean isExpectationAboveThreshold = task.sentence.truth.getExpectation() > nal.narParameters.DEFAULT_CONFIRMATION_EXPECTATION;
         List<Concept.AnticipationEntry> confirmed = new ArrayList<>();
         for(Concept.AnticipationEntry entry : concept.anticipations) {
-            if(satisfiesAnticipation && !Stamp.baseOverlap(entry.predictionStamp, task.sentence.stamp) && isExpectationAboveThreshold && task.sentence.getOccurenceTime() > entry.negConfirm_abort_mintime) {
+            if(satisfiesAnticipation && /*!Stamp.baseOverlap(entry.predictionStamp, task.sentence.stamp) && */ isExpectationAboveThreshold && task.sentence.getOccurenceTime() >= entry.negConfirm_abort_mintime && task.sentence.getOccurenceTime() <= entry.negConfirm_abort_maxtime) {
                 confirmed.add(entry);
             }
         }

--- a/src/main/java/org/opennars/control/concept/ProcessGoal.java
+++ b/src/main/java/org/opennars/control/concept/ProcessGoal.java
@@ -24,7 +24,6 @@
 package org.opennars.control.concept;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -44,7 +43,6 @@ import static org.opennars.inference.LocalRules.revision;
 import static org.opennars.inference.LocalRules.trySolution;
 import org.opennars.inference.TemporalRules;
 import org.opennars.inference.TruthFunctions;
-import org.opennars.interfaces.Timable;
 import org.opennars.io.Symbols;
 import org.opennars.io.events.Events;
 import org.opennars.language.CompoundTerm;
@@ -53,17 +51,14 @@ import org.opennars.language.Equivalence;
 import org.opennars.language.Implication;
 import org.opennars.language.Interval;
 import org.opennars.language.Product;
-import org.opennars.language.Tense;
 import org.opennars.language.Term;
 import org.opennars.language.Variable;
 import org.opennars.language.Variables;
 import org.opennars.main.MiscFlags;
-import org.opennars.main.Parameters;
 import org.opennars.operator.FunctionOperator;
 import org.opennars.operator.Operation;
 import org.opennars.operator.Operator;
 import org.opennars.plugin.mental.InternalExperience;
-import org.opennars.storage.Memory;
 
 /**
  *
@@ -265,7 +260,6 @@ public class ProcessGoal {
         public long maxtime = -1;
         public float timeOffset;
         public Map<Term,Term> substitution;
-        public Stamp prediction_stamp = null;
     }
 
     /**
@@ -325,7 +319,7 @@ public class ProcessGoal {
                     float distance = precon.timeOffset - nal.time.time();
                     float urgency = 2.0f + 1.0f/distance;
 
-                    ProcessAnticipation.anticipate(nal, precon.prediction_stamp, precon.executable_precond.sentence, precon.executable_precond.budget, precon.mintime, precon.maxtime, urgency, precon.substitution);
+                    ProcessAnticipation.anticipate(nal, precon.executable_precond.sentence, precon.executable_precond.budget, precon.mintime, precon.maxtime, urgency, precon.substitution);
                 }
                 return; //don't try the other table as a specific solution was already used
             }
@@ -409,8 +403,8 @@ public class ProcessGoal {
             final TruthValue opdesire = TruthFunctions.desireDed(precon, leftside, concept.memory.narParameters);
             final float expecdesire = opdesire.getExpectation();
             Operation bestop = (Operation) ((CompoundTerm)op).applySubstitute(subsBest);
-            long mintime = (long) (nal.time.time() + timeOffset - timeWindowHalf);
-            long maxtime = (long) (nal.time.time() + timeOffset + timeWindowHalf);
+            long mintime = (long) (nal.time.time());
+            long maxtime = (long) (nal.time.time() + timeWindowHalf);
             if(expecdesire > result.bestop_truthexp) {
                 result.bestop = bestop;
                 result.bestop_truthexp = expecdesire;
@@ -420,7 +414,6 @@ public class ProcessGoal {
                 result.mintime = mintime;
                 result.maxtime = maxtime;
                 result.timeOffset = timeOffset;
-                result.prediction_stamp = new Stamp(new Stamp(projectedGoal.stamp, t.sentence.stamp, nal.time.time(), nal.narParameters),bestsofar.sentence.stamp, nal.time.time(), nal.narParameters);
                 if(anticipationsToMake.get(result.bestop) == null) {
                     anticipationsToMake.put(result.bestop, new ArrayList<ExecutablePrecondition>());
                 }

--- a/src/main/java/org/opennars/control/concept/ProcessTask.java
+++ b/src/main/java/org/opennars/control/concept/ProcessTask.java
@@ -55,6 +55,7 @@ public class ProcessTask {
     // called in Memory.localInference only, for both derived and input tasks
     public static boolean processTask(final Concept concept, final DerivationContext nal, final Task task, Timable time) {
         synchronized(concept) {
+            concept.observable |= task.isInput();
             final char type = task.sentence.punctuation;
             switch (type) {
                 case Symbols.JUDGMENT_MARK:

--- a/src/main/java/org/opennars/entity/Concept.java
+++ b/src/main/java/org/opennars/entity/Concept.java
@@ -118,6 +118,8 @@ public class Concept extends Item<Term> implements Serializable {
     //so that revision can decide whether to use the new or old term
     //based on which intervals are closer to the average
     public final List<Float> recent_intervals = new ArrayList<>();
+
+    public boolean observable = false; //whether it received a "native" input task
     public boolean allowBabbling = true; //for operations, becomes false if sufficiently
                                          //confident, used procedure knowledge  exists.
 
@@ -301,15 +303,13 @@ public class Concept extends Item<Term> implements Serializable {
     public static class AnticipationEntry implements Serializable {
         public float negConfirmationPriority = 0.0f;
         public Task negConfirmation = null;
-        public Stamp predictionStamp = null;
         public long negConfirm_abort_mintime = 0;
         public long negConfirm_abort_maxtime = 0;
-        public AnticipationEntry(float negConfirmationPriority, Task negConfirmation, long negConfirm_abort_mintime, long negConfirm_abort_maxtime, Stamp predictionStamp) {
+        public AnticipationEntry(float negConfirmationPriority, Task negConfirmation, long negConfirm_abort_mintime, long negConfirm_abort_maxtime) {
             this.negConfirmationPriority = negConfirmationPriority;
             this.negConfirmation = negConfirmation;
             this.negConfirm_abort_mintime = negConfirm_abort_mintime;
             this.negConfirm_abort_maxtime = negConfirm_abort_maxtime;
-            this.predictionStamp = predictionStamp;
         }
     }
     public List<AnticipationEntry> anticipations = new ArrayList<>();

--- a/src/main/java/org/opennars/inference/CompositionalRules.java
+++ b/src/main/java/org/opennars/inference/CompositionalRules.java
@@ -753,8 +753,10 @@ public final class CompositionalRules {
             }
             i++;
         }
-        Set<Set<Term>> powerset = powerSet(selected);
-        for(Set<Term> combo : powerset) {
+        //
+        Set<Term> combo  = selected;
+        /*fSet<Set<Term>> powerset = powerSet(selected);
+        or(Set<Term> combo : powerset)*/ {
             Map<Term,Term> mapping = new LinkedHashMap<>();
             for(Term vIntro : combo) {
                 mapping.put(vIntro, app.get(vIntro));
@@ -786,6 +788,9 @@ public final class CompositionalRules {
                 } else {
                     t = side;
                 }
+            }
+            if(!(t instanceof CompoundTerm)) {
+                candidates.add(t);
             }
             if(t instanceof Conjunction || t instanceof Disjunction || t instanceof Negation) { //component itself is a conjunction/disjunction
                 addVariableCandidates(candidates, t, subject);

--- a/src/main/java/org/opennars/inference/LocalRules.java
+++ b/src/main/java/org/opennars/inference/LocalRules.java
@@ -168,7 +168,11 @@ public class LocalRules {
                 }
                 for(int i=0;i<ivalNew.size();i++) {
                     final float Inbetween = (recent_ivals.get(i)+ivalNew.get(i)) / 2.0f; //vote as one new entry, turtle style
-                    final float speed = 1.0f / (nal.narParameters.INTERVAL_ADAPT_SPEED*(1.0f-newTruth.getExpectation())); //less truth expectation, slower
+                    float adapt = nal.narParameters.INTERVAL_ADAPT_SPEED_INCREASE;
+                    if(recent_ivals.get(i) > ivalNew.get(i)) {
+                        adapt = nal.narParameters.INTERVAL_ADAPT_SPEED_DECREASE;
+                    }
+                    final float speed = 1.0f / (adapt*(1.0f-newTruth.getExpectation())); //less truth expectation, slower
                     recent_ivals.set(i,recent_ivals.get(i)+speed*(Inbetween - recent_ivals.get(i)));
                 }
                 for(int i=0;i<ivalNew.size();i++) {

--- a/src/main/java/org/opennars/inference/RuleTables.java
+++ b/src/main/java/org/opennars/inference/RuleTables.java
@@ -97,7 +97,7 @@ public class RuleTables {
             
             //too restrictive, its checked for non-deductive inference rules in derivedTask (also for single prem)
             nal.evidentalOverlap = Stamp.baseOverlap(task.sentence.stamp, belief.stamp);
-            if(nal.evidentalOverlap && (!task.sentence.isEternal() || !belief.isEternal())) {
+            if(nal.evidentalOverlap /*&& (!task.sentence.isEternal() || !belief.isEternal())*/) {
                 return; //only allow for eternal reasoning for now to prevent derived event floods
             }
             

--- a/src/main/java/org/opennars/inference/StructuralRules.java
+++ b/src/main/java/org/opennars/inference/StructuralRules.java
@@ -494,6 +494,9 @@ public final class StructuralRules {
         Inheritance inheritance;
         Term newSubj, newPred;
         if (subject instanceof Product) {
+            if(((Product) subject).term.length > 2) {
+                return;
+            }
             final Product product = (Product) subject;
             final short i = index;
             if( product.term.length >= i + 1) {
@@ -556,6 +559,9 @@ public final class StructuralRules {
         Inheritance inheritance;
         Term newSubj, newPred;
         if (predicate instanceof Product) {
+            if(((Product) subject).term.length > 2) {
+                return;
+            }
             final Product product = (Product) predicate;
             final short i = index;
             if (product.term.length >= i+1) {
@@ -845,7 +851,7 @@ public final class StructuralRules {
      */
     static boolean structuralCompound(final CompoundTerm compound, final Term component, final boolean compoundTask, final int index, final DerivationContext nal) {
         
-        if(compound instanceof Conjunction) {
+        /*if(compound instanceof Conjunction) {
             if(nal.getCurrentTask().getTerm() == compound) {
                 final Conjunction conj = (Conjunction) compound; //only for # for now, will be gradually applied to &/ later
                 if(conj.getTemporalOrder() == TemporalRules.ORDER_FORWARD && conj.isSpatial) { //and some also to && &|
@@ -858,7 +864,7 @@ public final class StructuralRules {
                     seqToImage(conj, index, nal);
                 }
             }
-        }
+        }*/
         
         if (component.hasVarIndep()) { //moved down here since flattening also works when indep
             return false;
@@ -866,6 +872,11 @@ public final class StructuralRules {
         if ((compound instanceof Conjunction) && !compound.getIsSpatial() && (compound.getTemporalOrder() == TemporalRules.ORDER_FORWARD) && (index != 0)) {
             return false;
         } 
+        
+        //new control experiments without # operator takeout decomposition
+        if((compound instanceof Conjunction) && compound.getIsSpatial()) {
+            return false;
+        }
         
         final Term content = compoundTask ? component : compound;
         final Task task = nal.getCurrentTask();

--- a/src/main/java/org/opennars/inference/SyllogisticRules.java
+++ b/src/main/java/org/opennars/inference/SyllogisticRules.java
@@ -615,8 +615,8 @@ public final class SyllogisticRules {
                 if(taskSentence.getOccurenceTime() != Stamp.ETERNAL) {
                    float timeOffset = ((Interval) newCondition).time;
                    float timeWindowHalf = timeOffset * nal.narParameters.ANTICIPATION_TOLERANCE;
-                   mintime = (long) Math.max(taskSentence.getOccurenceTime(), (taskSentence.getOccurenceTime() + timeOffset - timeWindowHalf));
-                   maxtime = (long) (taskSentence.getOccurenceTime() + timeOffset + timeWindowHalf);
+                   mintime = (long) nal.time.time();
+                   maxtime = (long) (taskSentence.getOccurenceTime() + timeWindowHalf);
                    predictedEvent = nal.narParameters.RETROSPECTIVE_ANTICIPATIONS || (taskSentence.getOccurenceTime() >= nal.time.time());
                 }
              } else {
@@ -680,7 +680,7 @@ public final class SyllogisticRules {
         if(!nal.evidentalOverlap && ret != null && ret.size() > 0 && predictedEvent && taskSentence.isJudgment() && truth != null && 
             truth.getExpectation() > nal.narParameters.DEFAULT_CONFIRMATION_EXPECTATION && !premise1Sentence.stamp.alreadyAnticipatedNegConfirmation) {
             premise1Sentence.stamp.alreadyAnticipatedNegConfirmation = true;
-            ProcessAnticipation.anticipate(nal, nal.getTheNewStamp(), premise1Sentence, budget, mintime, maxtime, 1, new LinkedHashMap<Term,Term>());
+            ProcessAnticipation.anticipate(nal, premise1Sentence, budget, mintime, maxtime, 1, new LinkedHashMap<Term,Term>());
         }
     }
 

--- a/src/main/java/org/opennars/main/Parameters.java
+++ b/src/main/java/org/opennars/main/Parameters.java
@@ -236,7 +236,7 @@ public class Parameters implements Serializable {
     /** eternalized induction confidence to revise A =/&gt; B beliefs */
     public volatile float ANTICIPATION_CONFIDENCE = 0.1f;
 
-    public volatile float ANTICIPATION_TOLERANCE = 100.0f;
+    public volatile float ANTICIPATION_TOLERANCE = 2.0f;
     
     /** Retrospective anticipation, allow to check memory for content in case of anticipation (potential issue with forgetting) */
     public boolean RETROSPECTIVE_ANTICIPATIONS = false;

--- a/src/main/java/org/opennars/main/Parameters.java
+++ b/src/main/java/org/opennars/main/Parameters.java
@@ -245,7 +245,9 @@ public class Parameters implements Serializable {
     
     public volatile float COMPLEXITY_UNIT=1.0f; //1.0 - oo
     
-    public volatile float INTERVAL_ADAPT_SPEED = 4.0f;
+    //faster increase than decrease
+    public volatile float INTERVAL_ADAPT_SPEED_INCREASE = 2.0f;
+    public volatile float INTERVAL_ADAPT_SPEED_DECREASE = 4.0f;
  
     public int TASKLINK_PER_CONTENT = 4; //eternal/event are also seen extra
     

--- a/src/main/resources/config/defaultConfig.xml
+++ b/src/main/resources/config/defaultConfig.xml
@@ -97,7 +97,8 @@
     <conf name="SATISFACTION_TRESHOLD" value="0.0"/>
     <conf name="COMPLEXITY_UNIT" value="1.0"/>
     
-    <conf name="INTERVAL_ADAPT_SPEED" value="4.0"/>
+    <conf name="INTERVAL_ADAPT_SPEED_INCREASE" value="2.0"/>
+    <conf name="INTERVAL_ADAPT_SPEED_DECREASE" value="4.0"/>
     <conf name="TASKLINK_PER_CONTENT" value="4"/>
     
     <conf name="DEFAULT_FEEDBACK_PRIORITY" value="0.9"/>

--- a/src/main/resources/config/defaultConfig.xml
+++ b/src/main/resources/config/defaultConfig.xml
@@ -4,7 +4,7 @@
     <!-- NarParameters -->
     <conf name="NOVELTY_HORIZON" value="100000"/>
     <conf name="DECISION_THRESHOLD" value="0.51"/>
-    <conf name="CONCEPT_BAG_SIZE" value="10000"/>
+    <conf name="CONCEPT_BAG_SIZE" value="80000"/>
     <conf name="CONCEPT_BAG_LEVELS" value="1000"/>
     
     <conf name="DURATION" value="5"/>
@@ -85,14 +85,13 @@
     
     <conf name="BUSY_EVENT_HIGHER_THRESHOLD" value="0.9"/>
     <conf name="BUSY_EVENT_LOWER_THRESHOLD" value="0.1"/>
-    
     <conf name="BREAK_NAL_HOL_BOUNDARY" value="false"/>
     
     <conf name="QUESTION_GENERATION_ON_DECISION_MAKING" value="false"/>
     <conf name="HOW_QUESTION_GENERATION_ON_DECISION_MAKING" value="false"/>
     
     <conf name="ANTICIPATION_CONFIDENCE" value="0.1"/>
-    <conf name="ANTICIPATION_TOLERANCE" value="100.0"/>
+    <conf name="ANTICIPATION_TOLERANCE" value="2.0"/>
     <conf name="RETROSPECTIVE_ANTICIPATIONS" value="false"/>
     
     <conf name="SATISFACTION_TRESHOLD" value="0.0"/>
@@ -113,124 +112,15 @@
     <conf name="VARIABLE_INTRODUCTION_CONFIDENCE_MUL" value="0.9"/>
     <conf name="ANTICIPATIONS_PER_CONCEPT_MAX" value="8"/>
     <conf name="MOTOR_BABBLING_CONFIDENCE_THRESHOLD" value="0.8"/>
-    
+
     <conf name="THREADS_AMOUNT" value="1"/>
     <conf name="VOLUME" value="100"/>
     <conf name="MILLISECONDS_PER_STEP" value="0"/>
     <conf name="STEPS_CLOCK" value="true"/>
-    
+
     <!-- plugins -->
     <plugins>
-        <!-- plugins -->
-        <plugin classpath="org.opennars.plugin.mental.Emotions">
-            <arg type="float.class" value="0.25" name="HAPPY_EVENT_LOWER_THRESHOLD"/>
-            <arg type="float.class" value="0.75" name="HAPPY_EVENT_HIGHER_THRESHOLD"/>
-            <arg type="float.class" value="0.1" name="BUSY_EVENT_LOWER_THRESHOLD"/>
-            <arg type="float.class" value="0.9" name="BUSY_EVENT_HIGHER_THRESHOLD"/>
-            <arg type="int.class" value="1000" name="CHANGE_STEPS_DEMANDED"/>
-        </plugin>
-        <plugin classpath="org.opennars.operator.mental.Anticipate">
-            <arg type="float.class" value="0.1" name="ANTICIPATION_DURABILITY_MUL"/>
-            <arg type="float.class" value="0.1" name="ANTICIPATION_PRIORITY_MUL"/>
-        </plugin>
-        <plugin classpath="org.opennars.plugin.mental.InternalExperience">
-            <arg type="float.class" value="0.3" name="MINIMUM_PRIORITY_TO_CREATE_WANT_BELIEVE_ETC"/>
-            <arg type="float.class" value="0.3" name="MINIMUM_PRIORITY_TO_CREATE_WONDER_EVALUATE"/>
-            <arg type="float.class" value="0.0001" name="INTERNAL_EXPERIENCE_PROBABILITY"/>
-            <arg type="float.class" value="0.000025" name="INTERNAL_EXPERIENCE_RARE_PROBABILITY"/>
-            <arg type="float.class" value="0.1" name="INTERNAL_EXPERIENCE_DURABILITY_MUL"/>
-            <arg type="float.class" value="0.1" name="INTERNAL_EXPERIENCE_PRIORITY_MUL"/>
-            <arg type="boolean.class" value="true" name="ALLOW_WANT_BELIEF"/>
-            <arg type="boolean.class" value="false" name="OLD_BELIEVE_WANT_EVALUATE_WONDER_STRATEGY"/>
-            <arg type="boolean.class" value="false" name="FULL_REFLECTION"/>
-        </plugin>
-
-        <plugin classpath="org.opennars.plugin.perception.VisionChannel">
-            <arg type="String.class" value="BRIGHT" name="label"/>
-            <arg isReasoner="nar" name="Nar instance"/>
-            <arg isReasoner="nar" name="reportResultsTo"/>
-            <arg type="int.class" value="5" name="width"/>
-            <arg type="int.class" value="5" name="height"/>
-            <arg type="int.class" value="25" name="duration"/>
-            <arg type="float.class" value="0.1" name="defaultOutputConfidence"/>
-            <arg type="int.class" value="0" name="nPrototypes"/>
-        </plugin>
-
-        <!-- example Operators -->
-        <plugin classpath="org.opennars.operator.NullOperator">
-            <arg type="String.class" value="^break"/>
-        </plugin>
-        <plugin classpath="org.opennars.operator.NullOperator">
-            <arg type="String.class" value="^drop"/>
-        </plugin>
-        <plugin classpath="org.opennars.operator.NullOperator">
-            <arg type="String.class" value="^go-to"/>
-        </plugin>
-        <plugin classpath="org.opennars.operator.NullOperator">
-            <arg type="String.class" value="^open"/>
-        </plugin>
-        <plugin classpath="org.opennars.operator.NullOperator">
-            <arg type="String.class" value="^pick"/>
-        </plugin>
-        <plugin classpath="org.opennars.operator.NullOperator">
-            <arg type="String.class" value="^strike"/>
-        </plugin>
-        <plugin classpath="org.opennars.operator.NullOperator">
-            <arg type="String.class" value="^throw"/>
-        </plugin>
-        <plugin classpath="org.opennars.operator.NullOperator">
-            <arg type="String.class" value="^activate"/>
-        </plugin>
-        <plugin classpath="org.opennars.operator.NullOperator">
-            <arg type="String.class" value="^deactivate"/>
-        </plugin>
-        <plugin classpath="org.opennars.operator.NullOperator">
-            <arg type="String.class" value="^lighter"/>
-        </plugin>
-        <plugin classpath="org.opennars.operator.NullOperator">
-            <arg type="String.class" value="^reshape"/>
-        </plugin>
-        <plugin classpath="org.opennars.operator.NullOperator">
-            <arg type="String.class" value="^escape"/>
-        </plugin>
-        <plugin classpath="org.opennars.operator.NullOperator">
-            <arg type="String.class" value="^say"/>
-        </plugin>
-        <plugin classpath="org.opennars.operator.NullOperator">
-            <arg type="String.class" value="^right"/>
-        </plugin>
-        <plugin classpath="org.opennars.operator.NullOperator">
-            <arg type="String.class" value="^left"/>
-        </plugin>
-        <plugin classpath="org.opennars.operator.NullOperator">
-            <arg type="String.class" value="^run"/>
-        </plugin>
-        <plugin classpath="org.opennars.operator.NullOperator">
-            <arg type="String.class" value="^feel"/>
-        </plugin>
-
-        <plugin classpath="org.opennars.operator.NullOperator"/>
-        
-        <plugin classpath="org.opennars.operator.mental.Believe"/>
-        <plugin classpath="org.opennars.operator.mental.Want"/>
-        <plugin classpath="org.opennars.operator.mental.Wonder"/>
-        <plugin classpath="org.opennars.operator.mental.Evaluate"/>
-
-        <plugin classpath="org.opennars.operator.mental.Remind"/>
-        <plugin classpath="org.opennars.operator.mental.Consider"/>
-        <plugin classpath="org.opennars.operator.mental.Name"/>
-        <plugin classpath="org.opennars.operator.mental.Register"/>
-
-        <plugin classpath="org.opennars.operator.mental.Doubt"/>
-        <plugin classpath="org.opennars.operator.mental.Hesitate"/>
-
-        <plugin classpath="org.opennars.operator.misc.Reflect"/>
-
-        <plugin classpath="org.opennars.operator.mental.FeelSatisfied"/>
-        <plugin classpath="org.opennars.operator.mental.FeelBusy"/>
-
-        <plugin classpath="org.opennars.operator.misc.Count"/>
-        <plugin classpath="org.opennars.operator.misc.Add"/>
+        <plugin classpath="org.opennars.operator.misc.System"/>
     </plugins>
 </config>
 

--- a/src/main/resources/config/mvpConfig.xml
+++ b/src/main/resources/config/mvpConfig.xml
@@ -91,7 +91,7 @@
     <conf name="HOW_QUESTION_GENERATION_ON_DECISION_MAKING" value="false"/>
     
     <conf name="ANTICIPATION_CONFIDENCE" value="0.1"/>
-    <conf name="ANTICIPATION_TOLERANCE" value="100.0"/>
+    <conf name="ANTICIPATION_TOLERANCE" value="2.0"/>
     <conf name="RETROSPECTIVE_ANTICIPATIONS" value="false"/>
     
     <conf name="SATISFACTION_TRESHOLD" value="0.0"/>
@@ -120,6 +120,7 @@
 
     <!-- plugins -->
     <plugins>
+        <plugin classpath="org.opennars.operator.misc.System"/>
     </plugins>
 </config>
 

--- a/src/main/resources/config/mvpConfig.xml
+++ b/src/main/resources/config/mvpConfig.xml
@@ -97,7 +97,8 @@
     <conf name="SATISFACTION_TRESHOLD" value="0.0"/>
     <conf name="COMPLEXITY_UNIT" value="1.0"/>
     
-    <conf name="INTERVAL_ADAPT_SPEED" value="4.0"/>
+    <conf name="INTERVAL_ADAPT_SPEED_INCREASE" value="2.0"/>
+    <conf name="INTERVAL_ADAPT_SPEED_DECREASE" value="4.0"/>
     <conf name="TASKLINK_PER_CONTENT" value="4"/>
     
     <conf name="DEFAULT_FEEDBACK_PRIORITY" value="0.9"/>


### PR DESCRIPTION
not a real PR yet.

LIST:
no derivation of eternal sequences
sequence events do not enter concept memory anymore
no evidental base overlap allowed anymore, not even in deduction
no derivation of non-eternalized implications
no image transformation for images with size > 2 anymore
only deriving most general and most specific in var intro
termlink record for image transformations
anticipation again restricted to input (yes, not everything is always a step forward :) )
anticipation tolerance handling improved (ANSNA ideas)
temporal induction not generating <|> and retrospective anymore, they need to come from backward inference
variable introduction for part operator arguments (for NLP)
no structural inference for part operator (# ) anymore, it assumes triples for now
switched completely to MVP config meaning no NAL9 / introspective events / global measurements


